### PR TITLE
feat(security): install-script signal, signal combination rules, PEP 503 normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ After the [Axios supply chain attack](https://www.a16z.news/p/et-tu-agent-did-yo
 | **New Package Detection** | Brand-new packages with no history | < 7 days old |
 | **Low Downloads** | Packages with no community adoption (npm only) | < 100/week |
 | **Typosquat Detection** | Names 1–2 edits away from popular packages (`lodahs` → `lodash`) | offline, curated list |
+| **Install Scripts** | Packages that run `preinstall`/`install`/`postinstall` on install (npm only) | any lifecycle script |
 
-All three would have caught `plain-crypto-js`, the malicious package used in the Axios attack.
+These would have caught `plain-crypto-js`, the malicious package used in the Axios attack.
 
-Supply chain checks return `ask` (not `deny`) — you decide whether to proceed. CVE-based blocks remain automatic.
+A single supply chain signal returns `ask` — you decide whether to proceed. But high-risk **combinations** are blocked outright: a brand-new package that also runs install scripts (or has near-zero downloads), a just-published version with install scripts, or a likely typosquat with install scripts. CVE-based blocks remain automatic.
 
 ## Installation
 
@@ -123,7 +124,8 @@ NODE_ENV=production npm install evil-pkg
 | **CVE** | CRITICAL or HIGH | **Block** — requires manual approval |
 | **CVE** | MODERATE or unscored (UNKNOWN) | **Ask** — you decide |
 | **CVE** | LOW | **Allow** — with warning |
-| **Supply Chain** | Version < 72h / New package / Low downloads / Typosquat | **Ask** — you decide |
+| **Supply Chain** | High-risk combination (e.g. new package + install scripts) | **Block** — requires manual approval |
+| **Supply Chain** | Single signal: version < 72h / new package / low downloads / typosquat / install scripts | **Ask** — you decide |
 | None found | — | **Allow** |
 
 Supply chain checks run in parallel with CVE checks (low added latency) and fail-open — if the registry is unreachable, installs proceed normally.

--- a/src/decision.test.ts
+++ b/src/decision.test.ts
@@ -55,3 +55,43 @@ describe('makeFullDecision', () => {
     expect(result.reason).toContain('Package created 2 days ago.');
   });
 });
+
+describe('makeFullDecision — signal combination rules', () => {
+  const newPackage = { type: 'new-package' as const, severity: 'HIGH' as const, detail: 'created 2 days ago' };
+  const installScript = { type: 'install-script' as const, severity: 'MEDIUM' as const, detail: 'runs postinstall' };
+  const lowDownloads = { type: 'low-downloads' as const, severity: 'MEDIUM' as const, detail: '3 weekly downloads' };
+  const quarantine = { type: 'version-quarantine' as const, severity: 'HIGH' as const, detail: 'published 1h ago' };
+  const typosquat = { type: 'typosquat' as const, severity: 'HIGH' as const, detail: '1 edit from lodash' };
+
+  it('denies new package + install script', () => {
+    const result = makeFullDecision([], [newPackage, installScript]);
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain('high-risk supply chain profile');
+  });
+
+  it('denies new package + low downloads', () => {
+    expect(makeFullDecision([], [newPackage, lowDownloads]).decision).toBe('deny');
+  });
+
+  it('denies version quarantine + install script', () => {
+    const result = makeFullDecision([], [quarantine, installScript]);
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain('compromised release');
+  });
+
+  it('denies typosquat + install script', () => {
+    expect(makeFullDecision([], [typosquat, installScript]).decision).toBe('deny');
+  });
+
+  it('only asks for a single new-package signal', () => {
+    expect(makeFullDecision([], [newPackage]).decision).toBe('ask');
+  });
+
+  it('only asks for a lone install-script signal', () => {
+    expect(makeFullDecision([], [installScript]).decision).toBe('ask');
+  });
+
+  it('still asks for new package + version quarantine (not a hard-block combo)', () => {
+    expect(makeFullDecision([], [newPackage, quarantine]).decision).toBe('ask');
+  });
+});

--- a/src/decision.ts
+++ b/src/decision.ts
@@ -95,6 +95,16 @@ export function makeFullDecision(
 
   const scReason = parts.join(' ');
 
+  // Combination rules: individually weak signals become decisive together.
+  // A brand-new package that also runs install scripts (or has near-zero
+  // adoption) is the classic fresh-malware profile — block it outright
+  // instead of just asking, which users learn to click through.
+  // (CVE deny was already handled above, so escalating to deny here is safe.)
+  const dangerousCombo = evaluateSignalCombination(signals);
+  if (dangerousCombo) {
+    return { decision: 'deny', reason: `🚫 ${dangerousCombo} ${scReason}` };
+  }
+
   // Escalate allow → ask if any supply chain signal fires
   if (cveResult.decision === 'allow') {
     return { decision: 'ask', reason: scReason };
@@ -102,4 +112,30 @@ export function makeFullDecision(
 
   // CVE was already 'ask' — combine reasons
   return { decision: 'ask', reason: `${cveResult.reason} ${scReason}` };
+}
+
+// Returns a human-readable reason when the signal set forms a high-risk
+// combination that warrants a hard block, or undefined otherwise.
+function evaluateSignalCombination(signals: SupplyChainSignal[]): string | undefined {
+  const has = (type: SupplyChainSignal['type']) => signals.some(s => s.type === type);
+
+  const newPackage = has('new-package');
+  const quarantine = has('version-quarantine');
+  const installScript = has('install-script');
+  const lowDownloads = has('low-downloads');
+  const typosquat = has('typosquat');
+
+  if (newPackage && installScript) {
+    return 'Brand-new package that runs install scripts — high-risk supply chain profile.';
+  }
+  if (newPackage && lowDownloads) {
+    return 'Brand-new package with almost no adoption — high-risk supply chain profile.';
+  }
+  if (quarantine && installScript) {
+    return 'Just-published version that runs install scripts — possible compromised release.';
+  }
+  if (typosquat && installScript) {
+    return 'Likely typosquat that runs install scripts — high-risk supply chain profile.';
+  }
+  return undefined;
 }

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -580,4 +580,33 @@ describe('parseInstallCommand', () => {
       ]);
     });
   });
+
+  describe('PyPI name normalization (PEP 503)', () => {
+    it('lowercases PyPI names', () => {
+      expect(parseInstallCommand('pip install Django')).toEqual([
+        { name: 'django', ecosystem: 'pypi' }
+      ]);
+    });
+
+    it('collapses underscores and dots to hyphens', () => {
+      expect(parseInstallCommand('pip install python_dateutil')).toEqual([
+        { name: 'python-dateutil', ecosystem: 'pypi' }
+      ]);
+      expect(parseInstallCommand('pip install zope.interface')).toEqual([
+        { name: 'zope-interface', ecosystem: 'pypi' }
+      ]);
+    });
+
+    it('preserves a pinned version while normalizing the name', () => {
+      expect(parseInstallCommand('pip install Flask_SQLAlchemy==2.5.1')).toEqual([
+        { name: 'flask-sqlalchemy', version: '2.5.1', ecosystem: 'pypi' }
+      ]);
+    });
+
+    it('does not alter npm package names (npm is case-sensitive)', () => {
+      expect(parseInstallCommand('npm install React_DOM')).toEqual([
+        { name: 'React_DOM', ecosystem: 'npm' }
+      ]);
+    });
+  });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -332,6 +332,14 @@ function detectInstallCommand(args: string[]): DetectResult | null {
   return null;
 }
 
+// PEP 503: PyPI treats runs of -, _, . as equivalent and is case-insensitive.
+// Normalize so OSV and registry lookups hit the canonical project name
+// (e.g. "Django" and "python_dateutil" → "django", "python-dateutil").
+function normalizePackageName(pkg: ParsedPackage): ParsedPackage {
+  if (pkg.ecosystem !== 'pypi') return pkg;
+  return { ...pkg, name: pkg.name.replace(/[-_.]+/g, '-').toLowerCase() };
+}
+
 export function parseInstallCommand(command: string): ParsedPackage[] | null {
   const allPackages: ParsedPackage[] = [];
 
@@ -346,7 +354,7 @@ export function parseInstallCommand(command: string): ParsedPackage[] | null {
       const install = detectInstallCommand(nested);
       if (install) {
         const packages = parsePackagesFromArgs(install.packageArgs, install.ecosystem);
-        allPackages.push(...packages);
+        allPackages.push(...packages.map(normalizePackageName));
       }
     }
   }

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -16,6 +16,7 @@ function npmRegistryResponse(overrides: {
   previousVersion?: string;
   previousPublished?: string;
   maintainers?: number;
+  scripts?: Record<string, string>;
 } = {}) {
   const now = new Date();
   const created = overrides.created ?? new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000).toISOString();
@@ -37,6 +38,10 @@ function npmRegistryResponse(overrides: {
     },
     'dist-tags': { latest: latestVersion },
     maintainers,
+    versions: {
+      [previousVersion]: { scripts: {} },
+      [latestVersion]: { scripts: overrides.scripts ?? {} },
+    },
   };
 }
 
@@ -358,6 +363,48 @@ describe('checkRegistryMetadata', () => {
 
       const result = await checkRegistryMetadata('any-pkg', undefined, 'pypi');
       expect(result).toEqual({ status: 'success', signals: [] });
+    });
+  });
+
+  describe('npm — install scripts', () => {
+    it('flags a package with a postinstall script', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('api.npmjs.org')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(npmDownloadsResponse(50000)) });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(npmRegistryResponse({
+            latestVersion: '3.0.0',
+            scripts: { postinstall: 'node ./setup.js' },
+          })),
+        });
+      });
+
+      const result = await checkRegistryMetadata('some-native-pkg', '3.0.0', 'npm');
+      const signal = result.signals.find(s => s.type === 'install-script');
+      expect(signal).toBeDefined();
+      expect(signal!.severity).toBe('MEDIUM');
+      expect(signal!.detail).toContain('postinstall');
+      expect(signal!.suggestion).toContain('--ignore-scripts');
+    });
+
+    it('does not flag a package without lifecycle scripts', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('api.npmjs.org')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(npmDownloadsResponse(50000)) });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(npmRegistryResponse({
+            latestVersion: '3.0.0',
+            scripts: { test: 'vitest', build: 'tsc' },
+          })),
+        });
+      });
+
+      const result = await checkRegistryMetadata('clean-pkg', '3.0.0', 'npm');
+      expect(result.signals.find(s => s.type === 'install-script')).toBeUndefined();
     });
   });
 });

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -7,11 +7,15 @@ const LOW_DOWNLOAD_THRESHOLD = 100;
 const REGISTRY_TIMEOUT_MS = 3000;
 
 export interface SupplyChainSignal {
-  type: 'version-quarantine' | 'new-package' | 'low-downloads' | 'typosquat';
+  type: 'version-quarantine' | 'new-package' | 'low-downloads' | 'typosquat' | 'install-script';
   severity: 'HIGH' | 'MEDIUM';
   detail: string;
   suggestion?: string;
 }
+
+// npm lifecycle scripts that execute automatically on install — the vector
+// most npm malware relies on to run its payload.
+const INSTALL_SCRIPT_HOOKS = ['preinstall', 'install', 'postinstall'] as const;
 
 export interface RegistryResult {
   status: 'success' | 'error';
@@ -71,6 +75,7 @@ interface NpmRegistryResponse {
   time?: Record<string, string>;
   maintainers?: Array<{ name?: string }>;
   'dist-tags'?: Record<string, string>;
+  versions?: Record<string, { scripts?: Record<string, string> }>;
 }
 
 interface NpmDownloadsResponse {
@@ -148,6 +153,21 @@ async function checkNpm(
         type: 'new-package',
         severity: 'HIGH',
         detail: `${name} was created ${formatAge(packageAge * 24)}. This package has no established history.`,
+      });
+    }
+  }
+
+  // H4: Install Scripts — the full registry doc carries each version's
+  // package.json scripts, so no extra request is needed.
+  if (resolvedVersion) {
+    const scripts = data.versions?.[resolvedVersion]?.scripts ?? {};
+    const present = INSTALL_SCRIPT_HOOKS.filter(hook => typeof scripts[hook] === 'string');
+    if (present.length > 0) {
+      signals.push({
+        type: 'install-script',
+        severity: 'MEDIUM',
+        detail: `${name}@${resolvedVersion} runs ${present.join('/')} script(s) on install — code executes automatically.`,
+        suggestion: 'Install with --ignore-scripts if you do not trust this package.',
       });
     }
   }


### PR DESCRIPTION
Round 2 of fraud-protection improvements — three detection-pipeline changes that sharpen the supply chain signals from PR #23.

## 1. Install-script detection (PRO-375)

`preinstall`/`install`/`postinstall` lifecycle scripts are the execution vector for essentially all npm malware. The full npm registry document already carries each version's `scripts`, so `registry.ts` now inspects it and raises a `MEDIUM` `install-script` signal — **no extra HTTP request**.

## 2. Signal combination rules (PRO-376)

Previously every supply chain signal escalated to `ask`, which users learn to click through. `decision.ts` now hard-**blocks** high-risk combinations that form a fresh-malware profile:

| Combination | Decision |
|---|---|
| new package + install script | **deny** |
| new package + low downloads | **deny** |
| version quarantine + install script | **deny** |
| typosquat + install script | **deny** |
| any single signal | **ask** (unchanged) |

CVE-based decisions still take priority.

## 3. PyPI name normalization (PRO-378)

`parser.ts` now normalizes PyPI names per PEP 503 (lowercase, collapse runs of `-`/`_`/`.` to `-`) so `Django` and `python_dateutil` resolve to the canonical `django` / `python-dateutil` for OSV and registry lookups. npm names are left untouched (npm is case-sensitive).

## Tests

- `registry.test.ts`: install-script signal present/absent (+2)
- `decision.test.ts`: every combo rule denies, lone signals still ask, non-combo pairs ask (+7)
- `parser.test.ts`: PyPI lowercase / separator collapse / version preserved / npm untouched (+4)
- All **150 tests pass**, `tsc --noEmit` clean

Closes PRO-375, PRO-376, PRO-378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTEvxicjPZXdx2hvmvnmzH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTEvxicjPZXdx2hvmvnmzH)_