### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-28
+
+### Added
+
+**Known-malware blocking (OSV `MAL-*`)**
+
+OSV advisories from the OpenSSF malicious-packages catalog (`MAL-*` ids)
+usually carry no CVSS score. Previously they collapsed through
+`UNKNOWN → NONE → allow`, so packages OSV explicitly flags as malware were
+installed with a reassuring message. They are now treated as `CRITICAL`
+(checked on the raw advisory id and aliases), and any unscored `UNKNOWN`
+advisory escalates to `ask` instead of silently passing.
+
+**Typosquat detection (offline)**
+
+Install names are compared against an embedded curated list of popular
+npm/PyPI packages using bounded Damerau-Levenshtein distance (transpositions
+like `lodahs` count as one edit). Near-misses raise a signal with a
+"Did you mean …?" hint. Runs entirely offline — no extra latency, no new
+failure mode.
+
+**Install-script detection (npm)**
+
+Packages that run `preinstall`/`install`/`postinstall` lifecycle scripts —
+the execution vector for most npm malware — now raise a supply chain signal.
+The full registry document already carries each version's scripts, so no
+extra request is made.
+
+**Signal combination rules**
+
+Individually weak supply chain signals are now hard-**blocked** when they
+form a fresh-malware profile: new package + install script, new package +
+low downloads, version quarantine + install script, or typosquat + install
+script. Single signals still return `ask`; CVE decisions still take priority.
+
+**Trusted-package allowlist + clean-result cache (`~/.patchpilot.json`)**
+
+- `allowlist` (exact name or `@scope/*` prefix) skips the supply-chain
+  heuristics but never the OSV CVE/malware check — an allowlist can never
+  unblock known-malicious code.
+- Clean `allow` results for an exact `name@version` are cached (24h default),
+  cutting latency on repeat installs and preventing fail-closed blocks during
+  brief OSV outages. Only `allow` is cached; `deny`/`ask` are always
+  re-evaluated and unversioned (`latest`) refs are never cached.
+- Config is zod-validated and fail-safe: a malformed file is ignored with a
+  warning rather than blocking installs.
+
+### Changed
+
+- PyPI package names are normalized per PEP 503 (lowercase, collapse runs of
+  `-`/`_`/`.`) before OSV and registry lookups, so `Django` and
+  `python_dateutil` resolve to their canonical project names. npm names are
+  left untouched.
+
+### Fixed
+
+- Packaging: the `files` allowlist now includes `dist/**` subdirectories, so
+  the embedded popular-packages data ships in the published tarball.
+
 ## [0.3.1] - 2026-04-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchpilot",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Security scanner for vibe coders - Claude Code hook that checks packages before installation",
   "type": "module",
   "main": "dist/index.js",
@@ -41,10 +41,10 @@
     "node": ">=18.0.0"
   },
   "files": [
-    "dist/*.js",
-    "dist/*.d.ts",
-    "!dist/*.test.js",
-    "!dist/*.test.d.ts",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "!dist/**/*.test.js",
+    "!dist/**/*.test.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Release prep for **v0.4.0** — bundles the fraud-protection work merged in #23, #24 and #25.

## Changes in this PR
- `package.json`: version `0.3.1` → `0.4.0`
- `CHANGELOG.md`: full `0.4.0` entry
- **Packaging fix:** `files` allowlist `dist/*.js` → `dist/**/*.js` (+ `.d.ts`, with `dist/**/*.test.*` excluded)

## Why the packaging fix matters

The typosquat feature loads `dist/data/popular-packages.js`. The old `dist/*.js` glob does **not** match subdirectories, so that file was excluded from the npm tarball — a v0.4.0 published without this fix would crash on any install command (failed import). Verified with `npm pack --dry-run`:

- `dist/data/popular-packages.js` now present in the tarball ✅
- no `*.test.js` files leak into the tarball ✅
- 20 files total, build + 165 tests green

## What ships in 0.4.0

| Feature | Source |
|---|---|
| Known-malware blocking (OSV `MAL-*`) + UNKNOWN → ask | #23 |
| Typosquat detection (offline) | #23 |
| Install-script signal (npm) | #24 |
| Signal combination rules (hard block) | #24 |
| PEP 503 PyPI name normalization | #24 |
| Allowlist + clean-result cache | #25 |

## Publishing (manual — needs npm credentials)

After merge, on `main`:

```bash
git pull && npm ci
npm publish            # runs prepublishOnly: build + test
git tag v0.4.0 && git push origin v0.4.0
```

Then create the GitHub Release from the tag. This completes Linear PRO-250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTEvxicjPZXdx2hvmvnmzH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTEvxicjPZXdx2hvmvnmzH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Erweiterte Erkennung und Blockierung schädlicher Pakete, einschließlich Malware-, Typosquat- und Install-Skript-Mustern.
  * Zusätzliche Regeln kombinieren mehrere Signale zu einer zuverlässigeren Sperrentscheidung.
  * Ein Allowlist- und Cache-Mechanismus verbessert saubere Prüfergebnisse und sorgt für robustes Fallback-Verhalten.

* **Änderungen**
  * PyPI-Paketnamen werden vor Abfragen jetzt standardkonform normalisiert.

* **Fehlerbehebungen**
  * Veröffentlichten Paketen werden nun auch die eingebetteten Daten aus den kompilierten Ausgaben mitgeliefert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->