### PR TITLE
chore(ci): switch release to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
-  id-token: write  # Required for provenance
+  contents: write  # Required to create the GitHub Release
+  id-token: write  # Required for OIDC trusted publishing + provenance
 
 jobs:
   release:
@@ -18,9 +18,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '22'  # Trusted publishing requires Node >= 22.14.0
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest  # OIDC trusted publishing requires npm >= 11.5.1
 
       - name: Install dependencies
         run: npm ci
@@ -29,12 +32,10 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm test -- --run
+        run: npm test
 
-      - name: Publish to npm with provenance
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm
+        run: npm publish  # Auth via OIDC trusted publishing; provenance is automatic
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,12 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write  # Required to create the GitHub Release
-  id-token: write  # Required for OIDC trusted publishing + provenance
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create the GitHub Release
+      id-token: write  # Required for OIDC trusted publishing + provenance
     steps:
       - uses: actions/checkout@v4
 
@@ -23,7 +22,7 @@ jobs:
           cache: 'npm'
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest  # OIDC trusted publishing requires npm >= 11.5.1
+        run: npm install -g npm@11.18.0  # OIDC trusted publishing requires npm >= 11.5.1; pinned for reproducible releases
 
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build && npm test"
   },
   "keywords": [


### PR DESCRIPTION
## Why

PatchPilot has never been published past `0.3.0` on npm, despite `0.3.1` and `0.4.0` being tagged/released in the repo:

- The `Release` workflow ran for `v0.3.0` and `v0.3.1` and **failed both times** on npm auth.
- The `v0.4.0` tag was **never pushed**, so the workflow never even ran for it.
- The `NPM_TOKEN` secret is read-only without publish scope, and the OTP/token dance has blocked every publish attempt since April.

## What

Switch the release workflow to **npm trusted publishing (OIDC)** so no token is ever needed again:

- Upgrade npm to the latest (OIDC trusted publishing requires `npm >= 11.5.1`)
- Pin Node `22` (trusted publishing requires `>= 22.14.0`)
- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` from the publish step
- Use plain `npm publish` — provenance is generated automatically under OIDC

Also fixes a long-standing footgun: `prepublishOnly` ran `npm test` → `vitest` in **watch mode**, which hung any local publish. `test` now runs `vitest run`; `test:watch` is kept for development.

## Required one-time setup (done in parallel, outside this PR)

On npmjs.com → package `patchpilot` → Settings → **Trusted Publisher**:
- Repository: `ProduktEntdecker/patchpilot-cli`
- Workflow: `release.yml`

## Release flow after merge

1. Merge this PR
2. Tag `v0.4.0` on `main` and push → triggers the workflow → publishes via OIDC
3. Verify `npm view patchpilot version` → `0.4.0`

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Der Release-Prozess wurde für Trusted Publishing über GitHub OIDC angepasst und modernisiert.
  * Node.js wird explizit auf Version 22 gesetzt; npm wird vorab auf eine passende Version aktualisiert.

* **Tests**
  * Der Test-Workflow wurde vereinfacht, sodass Tests ohne zusätzliche Parameter gestartet werden.
  * Zusätzlich gibt es einen separaten Watch-Modus für die lokale Testentwicklung.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->