### PR TITLE
feat(parser): vet update commands like installs + ChainDrop regression test

### DIFF
--- a/plans/transitive-dependency-coverage.md
+++ b/plans/transitive-dependency-coverage.md
@@ -47,6 +47,18 @@ runs; the audit catches transitive poison **after files land but typically
 before the developer executes the project** — and pinpoints exactly which
 transitive versions changed.
 
+### `npm ci` needs a different treatment
+
+`npm ci` produces **no lockfile diff** by definition — it installs exactly
+what the lockfile records, so a compromised version already recorded there
+never becomes a diff candidate and its install scripts run unchecked.
+Coverage for `npm ci` therefore cannot be diff-based: run a **pre-execution
+scan of the existing lockfile** instead (candidate set = all recorded
+entries; the v0.4.0 clean-result cache makes repeat scans cheap since only
+uncached `(name, version)` pairs hit the network). Until that scan ships,
+`npm ci` is explicitly **not covered** — the ChainDrop regression suite
+documents this limit as a test.
+
 ### Why not resolve the tree ourselves pre-execution?
 
 Considered and rejected for v0.5.x:
@@ -70,11 +82,14 @@ before the post-audit. Mitigation options, in preference order:
 1. Recommend `--ignore-scripts` as the default posture in agent sessions
    (PatchPilot can inject it or advise it; npm 11+ made this viable for most
    packages) and let the post-audit gate the first *execution* instead.
-2. For npm specifically: pre-run `npm install --dry-run
-   --package-lock-only` to compute the would-be lockfile without executing
-   scripts, then diff and gate **before** the real install. Slower (adds one
-   resolution pass) but closes the script-execution window entirely. Evaluate
-   as an opt-in `strict` mode.
+2. For npm specifically: pre-compute the would-be lockfile with
+   `npm install --package-lock-only --ignore-scripts` **in an isolated
+   working copy** (note: `--dry-run` cannot be used here — it suppresses the
+   lockfile write entirely, so there would be nothing to diff), then diff the
+   generated lockfile against the snapshot and gate **before** the real
+   install. Slower (adds one resolution pass) but closes the script-execution
+   window entirely. Evaluate as an opt-in `strict` mode; verify the flag
+   semantics against the npm versions we claim to support.
 
 ### Scope decisions for a first implementation
 

--- a/plans/transitive-dependency-coverage.md
+++ b/plans/transitive-dependency-coverage.md
@@ -1,0 +1,112 @@
+# Transitive Dependency Coverage — Design Evaluation
+
+**Status:** Evaluation (no implementation yet)
+**Created:** 2026-08-06, alongside v0.5.0
+**Context:** ChainDrop validation (see `src/chaindrop.test.ts`, Issue #30)
+
+## Problem Statement
+
+PatchPilot vets the packages **named on the command line**. That covers the
+direct vector — `npm install keyv` or `npm update keyv` while a poisoned
+version is live. It does not cover the **transitive** path, which was
+ChainDrop's dominant infection route:
+
+- `npm install` / `npm update` (bare or targeted) re-resolve semver ranges.
+  An existing `"keyv": "^5.6.0"` range pulls a freshly published poisoned
+  `5.6.1` without keyv ever appearing in the command PatchPilot parses.
+  A bare `npm install` names no packages at all.
+- `npm ci` installs only the exact versions recorded in the lockfile, so it
+  pulls no *new* poison in — but it faithfully installs a compromised version
+  that is already recorded there.
+
+Both cases are invisible to command-line parsing by construction. Closing the
+gap requires looking at what the package manager actually resolved — i.e. the
+**lockfile**.
+
+## Proposed Approach: Lockfile-Diff Checking
+
+### Core idea
+
+Hook the same PreToolUse event, but instead of only parsing the command:
+
+1. **Before** the install runs: snapshot the lockfile
+   (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`,
+   `poetry.lock`) — content hash plus parsed `(name, version)` set.
+2. Let the command run (PatchPilot cannot see resolution results before
+   execution — npm decides versions at run time).
+3. **After** the install (PostToolUse hook): diff the new lockfile against the
+   snapshot. Every **added or version-changed** entry is a candidate.
+4. Run the existing pipeline (OSV + registry signals + combination rules) over
+   the candidate set. On a deny-level finding: report loudly and offer the
+   rollback command (`git checkout -- package-lock.json && npm ci`, or the
+   ecosystem equivalent).
+
+This turns the check from *pre-execution gate* into *pre-execution gate +
+post-execution audit*. The gate still blocks the direct vector before code
+runs; the audit catches transitive poison **after files land but typically
+before the developer executes the project** — and pinpoints exactly which
+transitive versions changed.
+
+### Why not resolve the tree ourselves pre-execution?
+
+Considered and rejected for v0.5.x:
+
+- **Full resolution shadowing** (run `npm install --dry-run --json` or
+  Arborist first): accurate, but adds seconds of latency to every install,
+  duplicates package-manager logic per ecosystem, and drifts out of sync with
+  the user's actual npm/pnpm/yarn/bun version.
+- **Range auditing** (walk `package.json` ranges and check what they *could*
+  resolve to): cheap but speculative — flags poison that would not actually be
+  picked, misses overrides/resolutions, and cannot see hoisting decisions.
+
+The lockfile diff is the only source of truth for what was *actually*
+installed, and reading two lockfile states is milliseconds, not seconds.
+
+### Critical limitation to design around
+
+Install scripts of freshly added transitive packages run **during** step 2 —
+before the post-audit. Mitigation options, in preference order:
+
+1. Recommend `--ignore-scripts` as the default posture in agent sessions
+   (PatchPilot can inject it or advise it; npm 11+ made this viable for most
+   packages) and let the post-audit gate the first *execution* instead.
+2. For npm specifically: pre-run `npm install --dry-run
+   --package-lock-only` to compute the would-be lockfile without executing
+   scripts, then diff and gate **before** the real install. Slower (adds one
+   resolution pass) but closes the script-execution window entirely. Evaluate
+   as an opt-in `strict` mode.
+
+### Scope decisions for a first implementation
+
+| In scope (v0.6.0 candidate) | Out of scope |
+| --- | --- |
+| npm `package-lock.json` diff (largest attack surface, ChainDrop's route) | Vendored/git dependencies |
+| PostToolUse audit + rollback suggestion | Automatic rollback without user confirmation |
+| Reuse of existing OSV/registry/combination pipeline | New signal types |
+| `strict` opt-in: `--package-lock-only` pre-resolution for npm | Shadow resolution for pnpm/yarn/bun/poetry (follow-up) |
+
+### Performance budget
+
+The hook budget is ~10s (Claude Code hook timeout). Post-audit on a lockfile
+diff of N changed packages costs the same as N direct checks today (parallel
+OSV + registry, ~1–3s for typical diffs, plus cache hits for unchanged
+packages via the v0.4.0 clean-result cache). The `strict` pre-resolution mode
+adds one `npm install --package-lock-only` pass (~2–8s on medium projects) —
+acceptable only as opt-in.
+
+## Open Questions
+
+1. PostToolUse reporting channel: hook output is advisory at that point —
+   what is the strongest honest UX? (Deny-on-next-command until acknowledged?)
+2. Lockfile parsing: `@npmcli/arborist` vs. hand-rolled JSON/YAML readers —
+   dependency weight vs. correctness across lockfile versions.
+3. Monorepos: multiple lockfiles / workspaces — which ones to snapshot?
+4. Cache interaction: transitive-clean results should share the existing
+   clean-result cache keyed by `(ecosystem, name, version)`.
+
+## Decision
+
+Ship this document with v0.5.0 as the honest answer to "what about
+transitive dependencies?" — evaluation done, lockfile-diff selected as the
+approach, implementation targeted for the next minor release once the open
+questions above are resolved.

--- a/plans/transitive-dependency-coverage.md
+++ b/plans/transitive-dependency-coverage.md
@@ -82,14 +82,21 @@ before the post-audit. Mitigation options, in preference order:
 1. Recommend `--ignore-scripts` as the default posture in agent sessions
    (PatchPilot can inject it or advise it; npm 11+ made this viable for most
    packages) and let the post-audit gate the first *execution* instead.
-2. For npm specifically: pre-compute the would-be lockfile with
-   `npm install --package-lock-only --ignore-scripts` **in an isolated
-   working copy** (note: `--dry-run` cannot be used here — it suppresses the
-   lockfile write entirely, so there would be nothing to diff), then diff the
-   generated lockfile against the snapshot and gate **before** the real
-   install. Slower (adds one resolution pass) but closes the script-execution
-   window entirely. Evaluate as an opt-in `strict` mode; verify the flag
-   semantics against the npm versions we claim to support.
+2. For npm specifically: pre-compute the would-be lockfile **in an isolated
+   working copy** by re-running the **original command** with
+   `--package-lock-only --ignore-scripts` appended — e.g. `npm update keyv`
+   becomes `npm update keyv --package-lock-only --ignore-scripts`. The
+   pre-pass must preserve the operation (install vs. update), the package
+   arguments and effective options like `--omit`/`--workspace`, because a
+   generic `npm install --package-lock-only` does **not** perform the same
+   resolution as the user's update command and could leave the lockfile
+   unchanged while the real command would move versions. (`--dry-run` cannot
+   be used at all — it suppresses the lockfile write, so there would be
+   nothing to diff.) Then diff the generated lockfile against the snapshot
+   and gate **before** the real install. Slower (adds one resolution pass)
+   but closes the script-execution window entirely. Evaluate as an opt-in
+   `strict` mode; verify the flag semantics against the npm versions we
+   claim to support.
 
 ### Scope decisions for a first implementation
 

--- a/src/chaindrop.test.ts
+++ b/src/chaindrop.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseInstallCommand } from './parser.js';
+import { checkRegistryMetadata, type SupplyChainSignal } from './registry.js';
+import { checkPackageVulnerabilities } from './osv.js';
+import { makeFullDecision, type Vulnerability } from './decision.js';
+
+/**
+ * ChainDrop regression suite (August 2026).
+ *
+ * On Aug 4, 2026 the ChainDrop worm (a Shai-Hulud successor) hijacked the
+ * maintainer account behind keyv, cacheable, flat-cache and file-entry-cache
+ * and pushed freshly published versions carrying a
+ * `"preinstall": "node setup.mjs"` dropper. No CVE/OSV advisory existed while
+ * the malicious versions were live.
+ *
+ * This suite reconstructs npm's registry state from the attack window
+ * RELATIVE TO THE TEST CLOCK (keyv@6.0.0 tagged latest, two hours old,
+ * declaring the worm's preinstall hook), so the 72h-quarantine condition
+ * stays reproducible at any run date. It then asserts that the unmodified
+ * production pipeline hard-blocks the direct vector via the
+ * version-quarantine + install-script combination rule — with zero OSV data.
+ *
+ * Honest scope, mirrored in the launch content: this covers the DIRECT
+ * vector (installing/updating an affected package by name). The transitive
+ * path (fresh poison pulled in through existing semver ranges) is not
+ * covered; see plans/transitive-dependency-coverage.md.
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+const MALICIOUS_VERSION = '6.0.0';
+const PREVIOUS_STABLE = '5.6.0';
+
+// Registry state as it looked during the attack window, shifted to `now`
+function chainDropRegistryDoc(now: number) {
+  const iso = (msAgo: number) => new Date(now - msAgo).toISOString();
+  return {
+    time: {
+      created: iso(8 * 365 * DAY_MS),
+      modified: iso(2 * HOUR_MS),
+      [PREVIOUS_STABLE]: iso(94 * DAY_MS),
+      [MALICIOUS_VERSION]: iso(2 * HOUR_MS),
+    },
+    'dist-tags': { latest: MALICIOUS_VERSION },
+    maintainers: [{ name: 'jaredwray' }],
+    versions: {
+      [PREVIOUS_STABLE]: { scripts: {} },
+      [MALICIOUS_VERSION]: { scripts: { preinstall: 'node setup.mjs' } },
+    },
+  };
+}
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+
+  const doc = chainDropRegistryDoc(Date.now());
+
+  mockFetch.mockImplementation((url: string | URL) => {
+    const u = String(url);
+
+    // OSV knows nothing during the zero-day window
+    if (u.includes('api.osv.dev')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    }
+    // keyv is a top-1000 package — low-downloads must NOT fire
+    if (u.includes('api.npmjs.org')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ downloads: 120_000_000 }),
+      });
+    }
+    // /latest manifest used by OSV's version resolution
+    if (u.includes('registry.npmjs.org/keyv/latest')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ version: MALICIOUS_VERSION }),
+      });
+    }
+    // Full registry document
+    if (u.includes('registry.npmjs.org/keyv')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(doc) });
+    }
+    return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Full production pipeline for one parsed package, as src/index.ts wires it:
+// OSV check + registry metadata in parallel, then the combined decision.
+async function runPipeline(command: string) {
+  const packages = parseInstallCommand(command);
+  expect(packages).not.toBeNull();
+
+  const vulnerabilities: Vulnerability[] = [];
+  const signals: SupplyChainSignal[] = [];
+  for (const pkg of packages!) {
+    const [osv, registry] = await Promise.all([
+      checkPackageVulnerabilities(pkg.name, pkg.version, pkg.ecosystem),
+      checkRegistryMetadata(pkg.name, pkg.version, pkg.ecosystem),
+    ]);
+    expect(osv.status).toBe('success');
+    if (osv.status === 'success') {
+      for (const v of osv.vulnerabilities) {
+        vulnerabilities.push({
+          name: pkg.name,
+          version: pkg.version ?? 'latest',
+          severity: v.severity === 'MEDIUM' ? 'MODERATE' : v.severity,
+        });
+      }
+    }
+    if (registry.status === 'success') {
+      signals.push(...registry.signals);
+    }
+  }
+  return makeFullDecision(vulnerabilities, signals);
+}
+
+describe('ChainDrop attack window (keyv@6.0.0, preinstall dropper, no CVE)', () => {
+  it('hard-blocks `npm install keyv` while the malicious version is latest', async () => {
+    const result = await runPipeline('npm install keyv');
+
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain(
+      'Just-published version that runs install scripts — possible compromised release.'
+    );
+    expect(result.reason).toContain(`keyv@${MALICIOUS_VERSION} was published 2 hours ago`);
+    expect(result.reason).toContain('72h quarantine window');
+    expect(result.reason).toContain(`Consider using keyv@${PREVIOUS_STABLE} instead.`);
+  });
+
+  it('hard-blocks the pinned malicious version `npm install keyv@6.0.0`', async () => {
+    const result = await runPipeline(`npm install keyv@${MALICIOUS_VERSION}`);
+
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain(
+      'Just-published version that runs install scripts — possible compromised release.'
+    );
+  });
+
+  it('hard-blocks `npm update keyv` — the v0.4.0 parser bypass, fixed in v0.5.0', async () => {
+    // ChainDrop's primary direct vector: updates re-resolve semver ranges and
+    // pulled the poisoned release. v0.4.0 never parsed update commands at all.
+    const packages = parseInstallCommand('npm update keyv');
+    expect(packages).toEqual([{ name: 'keyv', ecosystem: 'npm' }]);
+
+    const result = await runPipeline('npm update keyv');
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain(
+      'Just-published version that runs install scripts — possible compromised release.'
+    );
+  });
+
+  it('blocks with ZERO OSV data — the deny comes from registry signals alone', async () => {
+    const result = await runPipeline('npm install keyv');
+
+    expect(result.decision).toBe('deny');
+    // Sanity check: the OSV mock returned no advisories, so the decision
+    // cannot have come from the CVE path.
+    const osvCalls = mockFetch.mock.calls.filter(([u]) => String(u).includes('api.osv.dev'));
+    expect(osvCalls.length).toBeGreaterThan(0);
+  });
+
+  it('does not fire once the same release has aged out of the quarantine window', async () => {
+    // Same registry state, but the "malicious" version is now 90 days old and
+    // OSV would long have a MAL advisory — quarantine alone must go quiet.
+    const doc = chainDropRegistryDoc(Date.now() - 90 * DAY_MS + 2 * HOUR_MS);
+    mockFetch.mockImplementation((url: string | URL) => {
+      const u = String(url);
+      if (u.includes('api.osv.dev')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      if (u.includes('api.npmjs.org')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ downloads: 120_000_000 }) });
+      }
+      if (u.includes('registry.npmjs.org/keyv/latest')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ version: MALICIOUS_VERSION }) });
+      }
+      if (u.includes('registry.npmjs.org/keyv')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(doc) });
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+    });
+
+    const registry = await checkRegistryMetadata('keyv', undefined, 'npm');
+    expect(registry.signals.find(s => s.type === 'version-quarantine')).toBeUndefined();
+  });
+
+  describe('honest scope — documented limits of the direct-vector coverage', () => {
+    it('does not parse bare `npm install` (names no packages)', () => {
+      // A bare install re-resolves ranges and can pull poisoned transitives
+      // PatchPilot never sees. Tracked in plans/transitive-dependency-coverage.md.
+      expect(parseInstallCommand('npm install')).toBeNull();
+    });
+
+    it('does not parse `npm ci` (lockfile-recorded versions only)', () => {
+      // npm ci pulls no NEW poison in, but faithfully installs a compromised
+      // version already recorded in the lockfile — out of scope by design.
+      expect(parseInstallCommand('npm ci')).toBeNull();
+    });
+  });
+});

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -126,6 +126,44 @@ describe('parseInstallCommand', () => {
         { name: 'lodash', ecosystem: 'npm' }
       ]);
     });
+
+    // Flag semantics are per package manager — a shared table would either
+    // skip real packages (unchecked installs) or flag option values.
+    describe('manager-specific flag semantics', () => {
+      it('pnpm --workspace is boolean: the package after it MUST be checked', () => {
+        expect(parseInstallCommand('pnpm update -r --workspace express')).toEqual([
+          { name: 'express', ecosystem: 'npm' }
+        ]);
+      });
+
+      it('pnpm --filter takes a value: filter target is not a package', () => {
+        expect(parseInstallCommand('pnpm update --filter @myorg/app express')).toEqual([
+          { name: 'express', ecosystem: 'npm' }
+        ]);
+      });
+
+      it('yarn --scope takes a value', () => {
+        expect(parseInstallCommand('yarn upgrade --scope @myorg')).toBeNull();
+      });
+
+      it('yarn --pattern takes a value', () => {
+        expect(parseInstallCommand('yarn upgrade --pattern gulp-')).toBeNull();
+      });
+
+      it('poetry --with takes a value: group name is not a package', () => {
+        expect(parseInstallCommand('poetry update --with dev')).toBeNull();
+      });
+
+      it('poetry --without value is skipped, real package is kept', () => {
+        expect(parseInstallCommand('poetry update --without dev requests')).toEqual([
+          { name: 'requests', ecosystem: 'pypi' }
+        ]);
+      });
+
+      it('pip -r requirements file is not a package name', () => {
+        expect(parseInstallCommand('pip install -r requirements.txt')).toBeNull();
+      });
+    });
   });
 
   describe('versioned packages', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -112,6 +112,20 @@ describe('parseInstallCommand', () => {
         { name: 'keyv', ecosystem: 'npm' }
       ]);
     });
+
+    it('does not treat option values as package names (--omit dev)', () => {
+      expect(parseInstallCommand('npm update --omit dev')).toBeNull();
+    });
+
+    it('does not treat workspace paths as package names', () => {
+      expect(parseInstallCommand('npm update --workspace packages/a')).toBeNull();
+    });
+
+    it('separates real packages from option values', () => {
+      expect(parseInstallCommand('npm update lodash --workspace packages/a')).toEqual([
+        { name: 'lodash', ecosystem: 'npm' }
+      ]);
+    });
   });
 
   describe('versioned packages', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -34,6 +34,86 @@ describe('parseInstallCommand', () => {
     });
   });
 
+  // Update commands re-resolve semver ranges and can pull a freshly poisoned
+  // release — `npm update <pkg>` was ChainDrop's primary direct vector.
+  describe('update commands (v0.5.0)', () => {
+    it('parses npm update', () => {
+      expect(parseInstallCommand('npm update keyv')).toEqual([
+        { name: 'keyv', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses npm upgrade (alias)', () => {
+      expect(parseInstallCommand('npm upgrade lodash')).toEqual([
+        { name: 'lodash', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses npm up (shorthand)', () => {
+      expect(parseInstallCommand('npm up lodash')).toEqual([
+        { name: 'lodash', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses pnpm update', () => {
+      expect(parseInstallCommand('pnpm update express')).toEqual([
+        { name: 'express', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses pnpm up', () => {
+      expect(parseInstallCommand('pnpm up express')).toEqual([
+        { name: 'express', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses yarn upgrade (Classic)', () => {
+      expect(parseInstallCommand('yarn upgrade react')).toEqual([
+        { name: 'react', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses yarn up (Berry)', () => {
+      expect(parseInstallCommand('yarn up react')).toEqual([
+        { name: 'react', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses yarn up with version range', () => {
+      expect(parseInstallCommand('yarn up lodash@4.17.21')).toEqual([
+        { name: 'lodash', version: '4.17.21', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses bun update', () => {
+      expect(parseInstallCommand('bun update zod')).toEqual([
+        { name: 'zod', ecosystem: 'npm' }
+      ]);
+    });
+
+    it('parses poetry update', () => {
+      expect(parseInstallCommand('poetry update requests')).toEqual([
+        { name: 'requests', ecosystem: 'pypi' }
+      ]);
+    });
+
+    it('returns null for bare npm update (no package named)', () => {
+      // Bare updates re-resolve the whole tree; tracked in
+      // plans/transitive-dependency-coverage.md, not parseable here.
+      expect(parseInstallCommand('npm update')).toBeNull();
+    });
+
+    it('returns null for bare yarn upgrade', () => {
+      expect(parseInstallCommand('yarn upgrade')).toBeNull();
+    });
+
+    it('vets update commands inside compound commands', () => {
+      expect(parseInstallCommand('cd /app && npm update keyv')).toEqual([
+        { name: 'keyv', ecosystem: 'npm' }
+      ]);
+    });
+  });
+
   describe('versioned packages', () => {
     it('parses npm package@version', () => {
       expect(parseInstallCommand('npm install lodash@4.17.21')).toEqual([

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -156,10 +156,21 @@ function parseNestedCommand(args: string[], depth = 0): string[][] {
   return [args];
 }
 
+// Options that take a separate value argument — the value must not be
+// mistaken for a package name (e.g. `npm update --omit dev` must not check
+// a package called "dev", `--workspace packages/a` no package "packages/a").
+// `--flag=value` forms are already skipped by the leading-dash check.
+const VALUE_TAKING_FLAGS = new Set([
+  '--omit', '--include', '--workspace', '-w', '--filter', '--mode', '--only',
+  '--loglevel', '--registry', '--prefix', '--cwd', '--dir', '--modules-folder',
+]);
+
 function parsePackagesFromArgs(args: string[], ecosystem: ParsedPackage['ecosystem']): ParsedPackage[] {
   const packages: ParsedPackage[] = [];
 
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (VALUE_TAKING_FLAGS.has(arg)) { i++; continue; } // Skip flag + its value
     if (arg.startsWith('-')) continue; // Skip flags
     if (arg.startsWith('.') || arg.startsWith('/')) continue; // Skip local paths
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -156,21 +156,54 @@ function parseNestedCommand(args: string[], depth = 0): string[][] {
   return [args];
 }
 
-// Options that take a separate value argument — the value must not be
-// mistaken for a package name (e.g. `npm update --omit dev` must not check
-// a package called "dev", `--workspace packages/a` no package "packages/a").
-// `--flag=value` forms are already skipped by the leading-dash check.
-const VALUE_TAKING_FLAGS = new Set([
-  '--omit', '--include', '--workspace', '-w', '--filter', '--mode', '--only',
-  '--loglevel', '--registry', '--prefix', '--cwd', '--dir', '--modules-folder',
-]);
+// Package manager whose flag syntax applies to the argument list.
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'pip' | 'poetry' | 'brew';
 
-function parsePackagesFromArgs(args: string[], ecosystem: ParsedPackage['ecosystem']): ParsedPackage[] {
+// Options that take a SEPARATE value argument, per package manager — the
+// value must not be mistaken for a package name (e.g. `npm update --omit dev`
+// must not check a package called "dev"). Flag semantics differ between
+// managers: npm's `--workspace` takes a value, pnpm's `--workspace` is a
+// boolean — a shared table would silently skip real packages. Keep these
+// lists conservative: a flag missing here means its value gets checked as a
+// package (a harmless false positive), while a boolean flag wrongly listed
+// here would skip a real package (an unchecked install).
+// `--flag=value` forms are already skipped by the leading-dash check.
+const VALUE_TAKING_FLAGS: Record<PackageManager, Set<string>> = {
+  npm: new Set([
+    '--omit', '--include', '--workspace', '-w', '--registry', '--loglevel',
+    '--prefix', '--tag', '--before', '--depth', '--script-shell',
+  ]),
+  pnpm: new Set([
+    // NOT --workspace: boolean for pnpm
+    '--filter', '-F', '--dir', '-C', '--registry', '--loglevel', '--reporter',
+    '--depth', '--store-dir', '--virtual-store-dir', '--lockfile-dir',
+  ]),
+  yarn: new Set([
+    '--scope', '--pattern', '--cwd', '--registry', '--modules-folder',
+    '--network-concurrency', '--mutex',
+  ]),
+  bun: new Set(['--cwd', '--registry', '--backend']),
+  pip: new Set([
+    '-i', '--index-url', '--extra-index-url', '--trusted-host', '-r',
+    '--requirement', '-c', '--constraint', '-t', '--target', '--platform',
+    '--python-version', '--proxy', '--retries', '--timeout', '--cache-dir',
+    '--root', '--prefix', '--src', '--log',
+  ]),
+  poetry: new Set(['--with', '--without', '--only', '-C', '--directory', '-P', '--project']),
+  brew: new Set([]),
+};
+
+function parsePackagesFromArgs(
+  args: string[],
+  ecosystem: ParsedPackage['ecosystem'],
+  manager: PackageManager
+): ParsedPackage[] {
   const packages: ParsedPackage[] = [];
+  const valueTaking = VALUE_TAKING_FLAGS[manager];
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (VALUE_TAKING_FLAGS.has(arg)) { i++; continue; } // Skip flag + its value
+    if (valueTaking.has(arg)) { i++; continue; } // Skip flag + its value
     if (arg.startsWith('-')) continue; // Skip flags
     if (arg.startsWith('.') || arg.startsWith('/')) continue; // Skip local paths
 
@@ -209,7 +242,11 @@ function parsePackagesFromArgs(args: string[], ecosystem: ParsedPackage['ecosyst
   return packages;
 }
 
-type DetectResult = { ecosystem: ParsedPackage['ecosystem']; packageArgs: string[] };
+type DetectResult = {
+  ecosystem: ParsedPackage['ecosystem'];
+  packageArgs: string[];
+  manager: PackageManager;
+};
 
 // Extract basename from potentially path-prefixed command
 function getBasename(cmd: string): string {
@@ -229,7 +266,7 @@ function detectInstallCommand(args: string[]): DetectResult | null {
 
   // P1-002: npm ecosystem - npm, npx, pnpm, yarn, bun
   if (['npm', 'pnpm'].includes(cmd) && ['install', 'i', 'add'].includes(subcmd)) {
-    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2), manager: cmd === 'pnpm' ? 'pnpm' : 'npm' };
   }
 
   // Update commands re-resolve semver ranges and can pull a freshly poisoned
@@ -237,7 +274,7 @@ function detectInstallCommand(args: string[]): DetectResult | null {
   // Vet named packages exactly like installs. Bare updates name no packages;
   // that path is tracked in plans/transitive-dependency-coverage.md.
   if (['npm', 'pnpm'].includes(cmd) && ['update', 'up', 'upgrade'].includes(subcmd)) {
-    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2), manager: cmd === 'pnpm' ? 'pnpm' : 'npm' };
   }
 
   // SECURITY FIX: npm link installs packages globally
@@ -245,36 +282,36 @@ function detectInstallCommand(args: string[]): DetectResult | null {
     const linkArgs = unwrapped.slice(2);
     // npm link (no args) = link current directory, npm link <pkg> = install <pkg>
     if (linkArgs.length > 0) {
-      return { ecosystem: 'npm', packageArgs: linkArgs };
+      return { ecosystem: 'npm', packageArgs: linkArgs, manager: 'npm' };
     }
   }
 
   if (cmd === 'yarn' && ['add', 'install'].includes(subcmd)) {
-    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2), manager: 'yarn' };
   }
 
   // yarn upgrade (Classic) / yarn up (Berry) — vetted like installs
   if (cmd === 'yarn' && ['upgrade', 'up'].includes(subcmd)) {
-    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2), manager: 'yarn' };
   }
 
   // yarn link
   if (cmd === 'yarn' && subcmd === 'link') {
     const linkArgs = unwrapped.slice(2);
     if (linkArgs.length > 0) {
-      return { ecosystem: 'npm', packageArgs: linkArgs };
+      return { ecosystem: 'npm', packageArgs: linkArgs, manager: 'yarn' };
     }
   }
 
   if (cmd === 'bun' && ['add', 'install', 'i', 'update'].includes(subcmd)) {
-    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2), manager: 'bun' };
   }
 
   // bun link
   if (cmd === 'bun' && subcmd === 'link') {
     const linkArgs = unwrapped.slice(2);
     if (linkArgs.length > 0) {
-      return { ecosystem: 'npm', packageArgs: linkArgs };
+      return { ecosystem: 'npm', packageArgs: linkArgs, manager: 'bun' };
     }
   }
 
@@ -316,41 +353,41 @@ function detectInstallCommand(args: string[]): DetectResult | null {
     }
 
     if (packagesToCheck.length > 0) {
-      return { ecosystem: 'npm', packageArgs: packagesToCheck };
+      return { ecosystem: 'npm', packageArgs: packagesToCheck, manager: 'npm' };
     }
   }
 
   // npm exec <package>
   if (cmd === 'npm' && subcmd === 'exec') {
-    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2), manager: 'npm' };
   }
 
   // P1-002: pip ecosystem - pip, pip3, pipx, uv, poetry
   if (['pip', 'pip3', 'pipx'].includes(cmd) && subcmd === 'install') {
-    return { ecosystem: 'pypi', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'pypi', packageArgs: unwrapped.slice(2), manager: 'pip' };
   }
 
   // uv pip install
   if (cmd === 'uv' && subcmd === 'pip' && unwrapped[2] === 'install') {
-    return { ecosystem: 'pypi', packageArgs: unwrapped.slice(3) };
+    return { ecosystem: 'pypi', packageArgs: unwrapped.slice(3), manager: 'pip' };
   }
 
   // poetry add / poetry update — update re-resolves ranges like an install
   if (cmd === 'poetry' && ['add', 'update'].includes(subcmd)) {
-    return { ecosystem: 'pypi', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'pypi', packageArgs: unwrapped.slice(2), manager: 'poetry' };
   }
 
   // python -m pip install (also handle full paths like /usr/bin/python3)
   const pythonBasename = getBasename(unwrapped[0]);
   if ((pythonBasename === 'python' || pythonBasename === 'python3') && subcmd === '-m') {
     if (unwrapped[2] === 'pip' && unwrapped[3] === 'install') {
-      return { ecosystem: 'pypi', packageArgs: unwrapped.slice(4) };
+      return { ecosystem: 'pypi', packageArgs: unwrapped.slice(4), manager: 'pip' };
     }
   }
 
   // homebrew - install, reinstall, upgrade
   if (cmd === 'brew' && ['install', 'reinstall', 'upgrade'].includes(subcmd)) {
-    return { ecosystem: 'homebrew', packageArgs: unwrapped.slice(2) };
+    return { ecosystem: 'homebrew', packageArgs: unwrapped.slice(2), manager: 'brew' };
   }
 
   return null;
@@ -377,7 +414,7 @@ export function parseInstallCommand(command: string): ParsedPackage[] | null {
     for (const nested of nestedCommands) {
       const install = detectInstallCommand(nested);
       if (install) {
-        const packages = parsePackagesFromArgs(install.packageArgs, install.ecosystem);
+        const packages = parsePackagesFromArgs(install.packageArgs, install.ecosystem, install.manager);
         allPackages.push(...packages.map(normalizePackageName));
       }
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -221,6 +221,14 @@ function detectInstallCommand(args: string[]): DetectResult | null {
     return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
   }
 
+  // Update commands re-resolve semver ranges and can pull a freshly poisoned
+  // release — `npm update <pkg>` was ChainDrop's primary direct vector (Aug 2026).
+  // Vet named packages exactly like installs. Bare updates name no packages;
+  // that path is tracked in plans/transitive-dependency-coverage.md.
+  if (['npm', 'pnpm'].includes(cmd) && ['update', 'up', 'upgrade'].includes(subcmd)) {
+    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
+  }
+
   // SECURITY FIX: npm link installs packages globally
   if (cmd === 'npm' && subcmd === 'link') {
     const linkArgs = unwrapped.slice(2);
@@ -234,6 +242,11 @@ function detectInstallCommand(args: string[]): DetectResult | null {
     return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
   }
 
+  // yarn upgrade (Classic) / yarn up (Berry) — vetted like installs
+  if (cmd === 'yarn' && ['upgrade', 'up'].includes(subcmd)) {
+    return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
+  }
+
   // yarn link
   if (cmd === 'yarn' && subcmd === 'link') {
     const linkArgs = unwrapped.slice(2);
@@ -242,7 +255,7 @@ function detectInstallCommand(args: string[]): DetectResult | null {
     }
   }
 
-  if (cmd === 'bun' && ['add', 'install', 'i'].includes(subcmd)) {
+  if (cmd === 'bun' && ['add', 'install', 'i', 'update'].includes(subcmd)) {
     return { ecosystem: 'npm', packageArgs: unwrapped.slice(2) };
   }
 
@@ -311,8 +324,8 @@ function detectInstallCommand(args: string[]): DetectResult | null {
     return { ecosystem: 'pypi', packageArgs: unwrapped.slice(3) };
   }
 
-  // poetry add
-  if (cmd === 'poetry' && subcmd === 'add') {
+  // poetry add / poetry update — update re-resolves ranges like an install
+  if (cmd === 'poetry' && ['add', 'update'].includes(subcmd)) {
     return { ecosystem: 'pypi', packageArgs: unwrapped.slice(2) };
   }
 


### PR DESCRIPTION
Closes #30

## What

1. **Parser: update commands are vetted like installs.** `npm`/`pnpm` `update|up|upgrade`, `yarn upgrade|up` (Classic + Berry), `bun update`, `poetry update`. Named packages get the full OSV + registry-signal pipeline. Bare updates (no package named) still return null — that path is transitive by construction and tracked in the new plan doc.
2. **`src/chaindrop.test.ts`** — permanent regression suite for the ChainDrop worm (Aug 4, 2026). Reconstructs npm's registry state from the attack window *relative to the test clock* (keyv@6.0.0 tagged latest, 2h old, `preinstall: node setup.mjs`, zero OSV data) so the 72h-quarantine condition reproduces at any run date. Asserts the unmodified pipeline hard-blocks install, pinned install and update vectors via the version-quarantine + install-script combination rule, and documents the honest-scope limits (`npm ci`, bare installs) as tests.
3. **`plans/transitive-dependency-coverage.md`** — design evaluation for closing the transitive gap (lockfile-diff checking selected; implementation targeted for the next minor).

## Why

Validating PatchPilot against ChainDrop confirmed the v0.4.0 combination rule fires inside the zero-day window — but also surfaced that `npm update <pkg>` bypassed the parser entirely, and updates were ChainDrop's primary direct vector. This is the v0.5.0 gate for the launch content in the patchpilot repo.

## Tests

185 passing (was 164): +14 update-command parser tests, +7 ChainDrop regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Update-Befehle von npm, pnpm, Yarn, Bun und Poetry werden jetzt als Paketänderungen erkannt.
  * Paketangaben aus diesen Befehlen können in Sicherheitsprüfungen berücksichtigt werden.
  * Bestehende Installationsbefehle bleiben unterstützt.

* **Tests**
  * Die Erkennung von Kurzformen, Aliasen und verketteten Shell-Befehlen wurde erweitert.
  * Prüfungen für riskante Installationsskripte, feste Versionen und Updates wurden abgesichert.

* **Dokumentation**
  * Die Prüfung transitiver Abhängigkeiten und möglicher Lockfile-Änderungen wurde evaluiert; die Umsetzung ist für eine spätere Version vorgesehen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->