### PR TITLE
chore(ci): add workflow_dispatch fallback to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual fallback: tag-push events are not reliably delivered for this repo
+  # (see #34) — run from the Actions tab or `gh workflow run release.yml
+  # --ref <tag>` with the tag checked out so npm publish sees the right version.
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Closes #34

Tag pushes (lightweight and annotated) are currently not delivered as workflow events for this repo — the v0.5.0 tag landed on the remote three times without a single release run, while PR workflows run fine. This adds `workflow_dispatch` as a manual fallback so a release can be started on the tag ref directly.

Unblocks the v0.5.0 npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)