### PR TITLE
fix(ci): allow coderabbitai bot to trigger claude review fallback

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,6 +59,18 @@ jobs:
           # ihre eigene Auth mit (Härtung, zizmor-Finding).
           persist-credentials: false
 
+      # Marketplace-Inhalt auf einen geprüften Commit gepinnt (Supply-Chain-
+      # Härtung): Die Action akzeptiert kein #ref/sha an der Marketplace-URL,
+      # wohl aber einen lokalen Pfad. SHA-Bump = bewusstes Plugin-Update.
+      - name: Checkout pinned Claude review marketplace
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: anthropics/claude-code
+          ref: 2bb60696142b493eafaeacfe00eac51d16c50c4f # main, 2026-08-08
+          path: .claude-code-marketplace
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
@@ -74,8 +86,11 @@ jobs:
           # Auch bei 0 Findings ein sichtbares Summary posten (Beleg, dass der
           # Reviewer lief).
           use_sticky_comment: true
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugin_marketplaces: './.claude-code-marketplace'
           plugins: 'code-review@claude-code-plugins'
           # issue_comment-Event: die PR-Nummer steht in issue.number
           # (pull_request.number ist hier null).
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'
+          # --comment ist zwingend: Ohne das Argument bricht das Plugin nach
+          # der Analyse ab und postet KEINE Kommentare (stiller No-op) —
+          # siehe plugins/code-review/commands/code-review.md, Step 7.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,13 +20,15 @@ on:
   issue_comment:
     types: [created]
 
-# Pro PR nur einen Fallback-Review gleichzeitig (z. B. bei Reopen).
-concurrency:
-  group: claude-review-pr-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   claude-review:
+    # Pro PR nur einen Fallback-Review gleichzeitig (z. B. bei Reopen).
+    # Job-Level statt Workflow-Level: Auf Workflow-Ebene würde jedes weitere
+    # issue_comment-Event derselben PR den laufenden Review canceln, obwohl
+    # der neue Lauf per if-Bedingung übersprungen wird.
+    concurrency:
+      group: claude-review-pr-${{ github.event.issue.number }}
+      cancel-in-progress: true
     # Drei Bedingungen, alle nötig:
     #  1. Kommentar hängt an einem PR (issue_comment feuert auch für Issues).
     #  2. Autor ist der CodeRabbit-Bot (gegen Spoofing des Markers).
@@ -53,16 +55,22 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          # Kein GITHUB_TOKEN in .git/config hinterlegen — die Action bringt
+          # ihre eigene Auth mit (Härtung, zizmor-Finding).
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Die Action blockt Bot-Actors standardmäßig — unser Trigger IST aber
-          # der CodeRabbit-Bot (Rate-Limit-Marker-Kommentar). Nur diesen einen
-          # Bot zulassen, kein '*'.
-          allowed_bots: coderabbitai
+          # Der Trigger-Kommentar stammt vom CodeRabbit-Bot — Bot-Events
+          # ignoriert die Action ohne diese Freigabe stillschweigend.
+          allowed_bots: 'coderabbitai'
+          # Workflow-Permissions allein reichen nicht: Auch der App-Token der
+          # Action braucht actions: read, damit Claude CI-Ergebnisse lesen kann.
+          additional_permissions: |
+            actions: read
           # Auch bei 0 Findings ein sichtbares Summary posten (Beleg, dass der
           # Reviewer lief).
           use_sticky_comment: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,6 +59,10 @@ jobs:
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Die Action blockt Bot-Actors standardmäßig — unser Trigger IST aber
+          # der CodeRabbit-Bot (Rate-Limit-Marker-Kommentar). Nur diesen einen
+          # Bot zulassen, kein '*'.
+          allowed_bots: coderabbitai
           # Auch bei 0 Findings ein sichtbares Summary posten (Beleg, dass der
           # Reviewer lief).
           use_sticky_comment: true


### PR DESCRIPTION
## Summary

Der CodeRabbit-Rate-Limit-Fallback in `claude-code-review.yml` ist heute erstmals real getriggert worden — und am Bot-Actor-Check der `claude-code-action` gescheitert ([Run 31256341965](https://github.com/ProduktEntdecker/patchpilot-cli/actions/runs/31256341965)):

```
Workflow initiated by non-human actor: coderabbitai (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Der Fallback wird per Design vom `coderabbitai[bot]`-Kommentar getriggert, der Actor ist also immer ein Bot — der Auto-Fallback konnte so noch nie durchlaufen.

## Fix

Synchronisiert die Datei mit der neuesten gehärteten Fassung (drfloriansteiner.com#260):

- **`allowed_bots: 'coderabbitai'`** — der eigentliche Bugfix. Bewusst kein `'*'`: nur der eine Bot, der den Marker postet; die drei `if:`-Guards (PR-Kontext, Bot-Login, Marker-String) bleiben unverändert. Die Action normalisiert das `[bot]`-Suffix selbst.
- **Concurrency auf Job- statt Workflow-Ebene** — auf Workflow-Ebene cancelt jedes weitere `issue_comment`-Event derselben PR den laufenden Review, obwohl der neue Lauf per `if` übersprungen wird.
- **`persist-credentials: false`** bei beiden Checkouts (zizmor-Härtung).
- **`additional_permissions: actions: read`** — Workflow-Permissions allein reichen nicht, auch der App-Token der Action braucht die Freigabe, um CI-Ergebnisse zu lesen.
- **Plugin-Marketplace auf Commit-SHA gepinnt** — Checkout von `anthropics/claude-code` auf festen SHA als lokaler Pfad statt un-gepinnter Git-URL; SHA-Bump = bewusstes Plugin-Update.

## Versionsstände in den Schwester-Repos

drfloriansteiner.com#260 hat exakt diese Fassung; patchpilot#21 (noch offen) fehlen `persist-credentials`/Marketplace-Pinning — wird dort separat nachgezogen.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * Parallele automatisierte Prüfungen für denselben Änderungsantrag werden zuverlässiger gesteuert und bei Bedarf abgebrochen.
  * Automatisierte Code-Reviews können nun auch durch Bot-Aktionen ausgelöst werden.
  * Review-Ergebnisse werden direkt als Kommentare veröffentlicht.
  * Die verwendeten Review-Komponenten werden reproduzierbarer und sicherer eingebunden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->